### PR TITLE
Implement missing HTML views

### DIFF
--- a/clientes/views.py
+++ b/clientes/views.py
@@ -3,6 +3,7 @@ from django.urls import reverse_lazy
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from django.shortcuts import get_object_or_404
+from django.db.models import Q
 
 from .models import Cliente
 
@@ -11,7 +12,7 @@ class ClienteListView(LoginRequiredMixin, ListView):
     """Vista para listar todos los clientes."""
     model = Cliente
     context_object_name = 'clientes'
-    template_name = 'clientes/lists/cliente_list.html'
+    template_name = 'clientes/cliente_list.html'
     paginate_by = 20
     
     def get_queryset(self):
@@ -32,7 +33,7 @@ class ClienteDetailView(LoginRequiredMixin, DetailView):
     """Vista para ver los detalles de un cliente específico."""
     model = Cliente
     context_object_name = 'cliente'
-    template_name = 'clientes/details/cliente_detail.html'
+    template_name = 'clientes/cliente_detail.html'
     
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -51,7 +52,7 @@ class ClienteCreateView(LoginRequiredMixin, PermissionRequiredMixin, CreateView)
         'nombre_contacto_principal', 'email_contacto_principal',
         'condiciones_pago', 'cupo_credito', 'activo'
     ]
-    template_name = 'clientes/forms/cliente_form.html'
+    template_name = 'clientes/cliente_form.html'
     permission_required = 'clientes.add_cliente'
     
     def form_valid(self, form):
@@ -72,7 +73,7 @@ class ClienteUpdateView(LoginRequiredMixin, PermissionRequiredMixin, UpdateView)
         'nombre_contacto_principal', 'email_contacto_principal',
         'condiciones_pago', 'cupo_credito', 'activo'
     ]
-    template_name = 'clientes/forms/cliente_form.html'
+    template_name = 'clientes/cliente_form.html'
     permission_required = 'clientes.change_cliente'
     
     def form_valid(self, form):

--- a/erp_config/urls.py
+++ b/erp_config/urls.py
@@ -2,6 +2,7 @@
 
 from django.contrib import admin
 from django.urls import path, include
+from productos.urls import api_urlpatterns as productos_api_urls
 from django.shortcuts import redirect
 from django.contrib.auth import views as auth_views
 
@@ -44,7 +45,7 @@ urlpatterns = [
     ], 'users'))),
 
     # --- Rutas para la API v1 ---
-    path('api/v1/', include(('productos.urls', 'api_productos'))),
+    path('api/v1/', include((productos_api_urls, 'api_productos'))),
     path('api/v1/produccion/', include(('produccion.urls', 'api_produccion'))),
     path('api/v1/inventario/', include(('inventario.urls', 'api_inventario'))),
     path('api/v1/pedidos/', include(('pedidos.urls', 'api_pedidos'))),

--- a/inventario/templates/inventario/lote_detail.html
+++ b/inventario/templates/inventario/lote_detail.html
@@ -141,7 +141,7 @@
                 <h5 class="modal-title">Transferir Lote</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
-            <form method="post" action="{% url 'inventario:transferir-lote' lote.id %}">
+            <form method="post" action="{% url 'inventario_web:transferir-lote' lote.id %}">
                 {% csrf_token %}
                 <div class="modal-body">
                     <div class="mb-3">
@@ -177,7 +177,7 @@
                 <h5 class="modal-title">Consumir del Lote</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
-            <form method="post" action="{% url 'inventario:consumir-lote' lote.id %}">
+            <form method="post" action="{% url 'inventario_web:consumir-lote' lote.id %}">
                 {% csrf_token %}
                 <div class="modal-body">
                     <div class="mb-3">

--- a/inventario/templates/inventario/materia_prima_detail.html
+++ b/inventario/templates/inventario/materia_prima_detail.html
@@ -13,14 +13,14 @@
         </div>
         <div class="col text-end">
             {% if materia_prima.estado == 'ACTIVO' %}
-            <a href="{% url 'inventario:materia-prima-update' materia_prima.id %}" class="btn btn-warning">
+            <a href="{% url 'inventario_web:materia-prima-update' materia_prima.id %}" class="btn btn-warning">
                 <i class="fas fa-edit"></i> Editar
             </a>
-            <a href="{% url 'inventario:lote-create' %}?materia_prima={{ materia_prima.id }}" class="btn btn-success">
+            <a href="{% url 'inventario_web:lote-create' %}?materia_prima={{ materia_prima.id }}" class="btn btn-success">
                 <i class="fas fa-plus"></i> Nuevo Lote
             </a>
             {% endif %}
-            <a href="{% url 'inventario:materia-prima-list' %}" class="btn btn-secondary">
+            <a href="{% url 'inventario_web:materia-prima-list' %}" class="btn btn-secondary">
                 <i class="fas fa-arrow-left"></i> Volver
             </a>
         </div>
@@ -147,7 +147,7 @@
                             </td>
                             <td>
                                 <div class="btn-group">
-                                    <a href="{% url 'inventario:lote-detail' lote.id %}" 
+                  <a href="{% url 'inventario_web:lote-detail' lote.id %}"
                                        class="btn btn-sm btn-info" 
                                        title="Ver Detalle">
                                         <i class="fas fa-eye"></i>
@@ -237,7 +237,7 @@
 <div class="modal fade" id="transferirModal" tabindex="-1">
     <div class="modal-dialog">
         <div class="modal-content">
-            <form method="post" action="{% url 'inventario:lote-transferir' %}">
+            <form method="post" action="{% url 'inventario_web:lote-transferir' %}">
                 {% csrf_token %}
                 <input type="hidden" name="lote_id" id="transferirLoteId">
                 
@@ -273,7 +273,7 @@
 <div class="modal fade" id="consumirModal" tabindex="-1">
     <div class="modal-dialog">
         <div class="modal-content">
-            <form method="post" action="{% url 'inventario:lote-consumir' %}">
+            <form method="post" action="{% url 'inventario_web:lote-consumir' %}">
                 {% csrf_token %}
                 <input type="hidden" name="lote_id" id="consumirLoteId">
                 

--- a/inventario/templates/inventario/materia_prima_form.html
+++ b/inventario/templates/inventario/materia_prima_form.html
@@ -22,7 +22,7 @@
                 {% endfor %}
                 <div class="mt-3">
                     <button type="submit" class="btn btn-primary">Guardar</button>
-                    <a href="{% url 'inventario:materia-prima-list' %}" class="btn btn-secondary">Cancelar</a>
+                    <a href="{% url 'inventario_web:materia-prima-list' %}" class="btn btn-secondary">Cancelar</a>
                 </div>
             </form>
         </div>

--- a/inventario/templates/inventario/materia_prima_list.html
+++ b/inventario/templates/inventario/materia_prima_list.html
@@ -9,7 +9,7 @@
             <h2><i class="fas fa-boxes"></i> Materias Primas</h2>
         </div>
         <div class="col text-end">
-            <a href="{% url 'inventario:materia-prima-create' %}" class="btn btn-primary">
+            <a href="{% url 'inventario_web:materia-prima-create' %}" class="btn btn-primary">
                 <i class="fas fa-plus"></i> Nueva Materia Prima
             </a>
         </div>
@@ -58,7 +58,7 @@
                     <button type="submit" class="btn btn-primary">
                         <i class="fas fa-search"></i> Filtrar
                     </button>
-                    <a href="{% url 'inventario:materia-prima-list' %}" class="btn btn-secondary">
+                    <a href="{% url 'inventario_web:materia-prima-list' %}" class="btn btn-secondary">
                         <i class="fas fa-times"></i> Limpiar
                     </a>
                 </div>
@@ -109,16 +109,16 @@
                             </td>
                             <td>
                                 <div class="btn-group">
-                                    <a href="{% url 'inventario:materia-prima-detail' mp.id %}" 
+                <a href="{% url 'inventario_web:materia-prima-detail' mp.id %}"
                                        class="btn btn-sm btn-info" title="Ver Detalle">
                                         <i class="fas fa-eye"></i>
                                     </a>
                                     {% if mp.estado == 'ACTIVO' %}
-                                    <a href="{% url 'inventario:materia-prima-update' mp.id %}" 
+                <a href="{% url 'inventario_web:materia-prima-update' mp.id %}"
                                        class="btn btn-sm btn-warning" title="Editar">
                                         <i class="fas fa-edit"></i>
                                     </a>
-                                    <a href="{% url 'inventario:lote-create' %}?materia_prima={{ mp.id }}" 
+                <a href="{% url 'inventario_web:lote-create' %}?materia_prima={{ mp.id }}"
                                        class="btn btn-sm btn-success" title="Nuevo Lote">
                                         <i class="fas fa-plus"></i>
                                     </a>

--- a/inventario/templates/inventario/movimientos_list.html
+++ b/inventario/templates/inventario/movimientos_list.html
@@ -56,7 +56,7 @@
                     <button type="submit" class="btn btn-primary">
                         <i class="fas fa-search"></i> Filtrar
                     </button>
-                    <a href="{% url 'inventario:movimientos' %}" class="btn btn-secondary">
+                    <a href="{% url 'inventario_web:movimiento-list' %}" class="btn btn-secondary">
                         <i class="fas fa-undo"></i> Limpiar
                     </a>
                 </div>

--- a/inventario/templates/inventario/stock_list.html
+++ b/inventario/templates/inventario/stock_list.html
@@ -56,7 +56,7 @@
                     <button type="submit" class="btn btn-primary">
                         <i class="fas fa-search"></i> Filtrar
                     </button>
-                    <a href="{% url 'inventario:stock-actual' %}" class="btn btn-secondary">
+                    <a href="{% url 'inventario_web:stock-list' %}" class="btn btn-secondary">
                         <i class="fas fa-undo"></i> Limpiar
                     </a>
                 </div>
@@ -102,10 +102,10 @@
                                 {% endif %}
                             </td>
                             <td>
-                                <a href="{% url 'inventario:detalle-item' item.id %}" class="btn btn-sm btn-info">
+                                <a href="{% url 'inventario_web:detalle-item' item.id %}" class="btn btn-sm btn-info">
                                     <i class="fas fa-eye"></i>
                                 </a>
-                                <a href="{% url 'inventario:movimientos-item' item.id %}" class="btn btn-sm btn-secondary">
+                                <a href="{% url 'inventario_web:movimientos-item' item.id %}" class="btn btn-sm btn-secondary">
                                     <i class="fas fa-history"></i>
                                 </a>
                             </td>

--- a/inventario/urls.py
+++ b/inventario/urls.py
@@ -1,24 +1,27 @@
 # inventario/urls.py
 from django.urls import path
 from .views import (
-    StockActualAPIView, 
-    MateriaPrimaListView, MateriaPrimaCreateView, MateriaPrimaUpdateView,
-    LoteListView, MovimientoListView
+    StockActualAPIView, StockListView,
+    MateriaPrimaListView, MateriaPrimaCreateView, MateriaPrimaUpdateView, MateriaPrimaDetailView,
+    LoteListView, LoteDetailView, MovimientoListView
 )
 
 # This should match the namespace used in erp_config/urls.py
 app_name = 'inventario_web'
 
 urlpatterns = [
-    path('stock/', StockActualAPIView.as_view(), name='stock-actual'),
+    path('stock/', StockListView.as_view(), name='stock-list'),
+    path('api/stock/', StockActualAPIView.as_view(), name='stock-actual'),
     
     # Materias Primas URLs
     path('materias-primas/', MateriaPrimaListView.as_view(), name='materia-prima-list'),
     path('materias-primas/crear/', MateriaPrimaCreateView.as_view(), name='materia-prima-create'),
     path('materias-primas/editar/<int:pk>/', MateriaPrimaUpdateView.as_view(), name='materia-prima-edit'),
+    path('materias-primas/<int:pk>/', MateriaPrimaDetailView.as_view(), name='materia-prima-detail'),
     
     # Lotes
     path('lotes/', LoteListView.as_view(), name='lote-list'),
+    path('lotes/<int:pk>/', LoteDetailView.as_view(), name='lote-detail'),
     
     # Movimientos de inventario
     path('movimientos/', MovimientoListView.as_view(), name='movimiento-list'),

--- a/pedidos/templates/pedidos/detalle.html
+++ b/pedidos/templates/pedidos/detalle.html
@@ -51,7 +51,7 @@
                                         <tr>
                                             <td><strong>Estado:</strong></td>
                                             <td>
-                                                <span class="badge badge-{{ pedido.estado|lower }} badge-lg">
+                                                <span class="badge bg-{{ pedido.estado|lower }} badge-lg">
                                                     {{ pedido.get_estado_display }}
                                                 </span>
                                             </td>
@@ -59,7 +59,7 @@
                                         <tr>
                                             <td><strong>Prioridad:</strong></td>
                                             <td>
-                                                <span class="badge badge-prioridad-{{ pedido.prioridad|lower }}">
+                                                <span class="badge bg-prioridad-{{ pedido.prioridad|lower }}">
                                                     {{ pedido.get_prioridad_display }}
                                                 </span>
                                             </td>
@@ -73,9 +73,9 @@
                                             <td>
                                                 {{ pedido.fecha_compromiso|date:"d/m/Y" }}
                                                 {% if pedido.es_vencido %}
-                                                    <span class="badge badge-danger ml-2">Vencido</span>
+                                                    <span class="badge bg-danger ms-2">Vencido</span>
                                                 {% elif pedido.es_proximo_vencer %}
-                                                    <span class="badge badge-warning ml-2">Próximo a vencer</span>
+                                                    <span class="badge bg-warning ms-2">Próximo a vencer</span>
                                                 {% endif %}
                                             </td>
                                         </tr>
@@ -188,7 +188,7 @@
                                                     <td>${{ linea.precio_unitario|floatformat:2 }}</td>
                                                     <td>${{ linea.subtotal|floatformat:2 }}</td>
                                                     <td>
-                                                        <span class="badge badge-{{ linea.estado|lower }}">
+                                                        <span class="badge bg-{{ linea.estado|lower }}">
                                                             {{ linea.get_estado_display }}
                                                         </span>
                                                     </td>
@@ -236,9 +236,9 @@
                                                 <h3 class="timeline-header">
                                                     <strong>{{ seguimiento.usuario.get_full_name|default:seguimiento.usuario.username }}</strong>
                                                     cambió el estado de 
-                                                    <span class="badge badge-secondary">{{ seguimiento.get_estado_anterior_display }}</span>
+                                                    <span class="badge bg-secondary">{{ seguimiento.get_estado_anterior_display }}</span>
                                                     a 
-                                                    <span class="badge badge-primary">{{ seguimiento.get_estado_nuevo_display }}</span>
+                                                    <span class="badge bg-primary">{{ seguimiento.get_estado_nuevo_display }}</span>
                                                 </h3>
                                                 {% if seguimiento.observaciones %}
                                                 <div class="timeline-body">

--- a/personal/views.py
+++ b/personal/views.py
@@ -11,7 +11,7 @@ class ColaboradorListView(LoginRequiredMixin, ListView):
     """Vista para listar todos los colaboradores."""
     model = Colaborador
     context_object_name = 'colaboradores'
-    template_name = 'personal/lists/colaborador_list.html'
+    template_name = 'personal/colaborador_list.html'
     paginate_by = 20
     
     def get_queryset(self):
@@ -32,7 +32,7 @@ class ColaboradorDetailView(LoginRequiredMixin, DetailView):
     """Vista para ver los detalles de un colaborador específico."""
     model = Colaborador
     context_object_name = 'colaborador'
-    template_name = 'personal/details/colaborador_detail.html'
+    template_name = 'personal/colaborador_detail.html'
     
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -48,7 +48,7 @@ class ColaboradorCreateView(LoginRequiredMixin, PermissionRequiredMixin, CreateV
         'cargo', 'area', 'fecha_ingreso', 'fecha_retiro',
         'usuario_sistema', 'is_active'
     ]
-    template_name = 'personal/forms/colaborador_form.html'
+    template_name = 'personal/colaborador_form.html'
     permission_required = 'personal.add_colaborador'
     
     def form_valid(self, form):
@@ -67,7 +67,7 @@ class ColaboradorUpdateView(LoginRequiredMixin, PermissionRequiredMixin, UpdateV
         'cargo', 'area', 'fecha_ingreso', 'fecha_retiro',
         'usuario_sistema', 'is_active'
     ]
-    template_name = 'personal/forms/colaborador_form.html'
+    template_name = 'personal/colaborador_form.html'
     permission_required = 'personal.change_colaborador'
     
     def form_valid(self, form):

--- a/productos/forms.py
+++ b/productos/forms.py
@@ -1,0 +1,21 @@
+from django import forms
+from .models import ProductoTerminado
+
+class ProductoTerminadoForm(forms.ModelForm):
+    class Meta:
+        model = ProductoTerminado
+        fields = [
+            'codigo', 'nombre', 'cliente', 'linea', 'sublinea',
+            'tipo_materia_prima', 'unidad_medida', 'estado',
+            'medida_en', 'largo', 'ancho', 'ancho_rollo',
+            'metros_lineales', 'calibre_um', 'factor_decimal',
+            'tipo_material', 'servicio', 'archivo_adjunto',
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            if isinstance(field.widget, forms.Select):
+                field.widget.attrs.setdefault('class', 'form-select')
+            else:
+                field.widget.attrs.setdefault('class', 'form-control')

--- a/productos/templates/productos/export.html
+++ b/productos/templates/productos/export.html
@@ -11,7 +11,7 @@
                 <div class="card-header">
                     <div class="d-flex justify-content-between align-items-center">
                         <h3 class="card-title mb-0">Exportar Productos</h3>
-                        <a href="{% url 'productos:producto_list' %}" class="btn btn-outline-secondary">
+                        <a href="{% url 'productos_web:producto-list' %}" class="btn btn-outline-secondary">
                             <i class="bi bi-arrow-left"></i> Volver
                         </a>
                     </div>

--- a/productos/templates/productos/import.html
+++ b/productos/templates/productos/import.html
@@ -11,7 +11,7 @@
                 <div class="card-header">
                     <div class="d-flex justify-content-between align-items-center">
                         <h3 class="card-title mb-0">Importar Productos</h3>
-                        <a href="{% url 'productos:producto_list' %}" class="btn btn-outline-secondary">
+                        <a href="{% url 'productos_web:producto-list' %}" class="btn btn-outline-secondary">
                             <i class="bi bi-arrow-left"></i> Volver
                         </a>
                     </div>
@@ -30,7 +30,7 @@
                     </div>
 
                     <div class="mb-4">
-                        <a href="{% url 'productos:download_template' %}" class="btn btn-success">
+                        <a href="{% url 'productos_web:download_template' %}" class="btn btn-success">
                             <i class="bi bi-file-earmark-excel"></i> Descargar Plantilla
                         </a>
                     </div>

--- a/productos/templates/productos/producto_detail.html
+++ b/productos/templates/productos/producto_detail.html
@@ -15,13 +15,13 @@
                     <small class="text-muted">{{ producto.codigo }}</small>
                 </div>
                 <div>
-                    <a href="{% url 'productos:producto_duplicate' producto.pk %}" class="btn btn-secondary">
+                    <a href="{% url 'productos_web:producto-duplicate' producto.pk %}" class="btn btn-secondary">
                         <i class="bi bi-files"></i> Duplicar
                     </a>
-                    <a href="{% url 'productos:producto_update' producto.pk %}" class="btn btn-primary">
+                    <a href="{% url 'productos_web:producto-update' producto.pk %}" class="btn btn-primary">
                         <i class="bi bi-pencil"></i> Editar
                     </a>
-                    <a href="{% url 'productos:producto_list' %}" class="btn btn-outline-secondary">
+                    <a href="{% url 'productos_web:producto-list' %}" class="btn btn-outline-secondary">
                         <i class="bi bi-arrow-left"></i> Volver
                     </a>
                 </div>

--- a/productos/templates/productos/producto_form.html
+++ b/productos/templates/productos/producto_form.html
@@ -11,7 +11,7 @@
                 <div class="card-header">
                     <div class="d-flex justify-content-between align-items-center">
                         <h3 class="card-title mb-0">{{ object.pk|yesno:"Editar,Nuevo" }} Producto</h3>
-                        <a href="{% url 'productos:producto_list' %}" class="btn btn-outline-secondary">
+                        <a href="{% url 'productos_web:producto-list' %}" class="btn btn-outline-secondary">
                             <i class="bi bi-arrow-left"></i> Volver
                         </a>
                     </div>

--- a/productos/templates/productos/producto_list.html
+++ b/productos/templates/productos/producto_list.html
@@ -8,13 +8,13 @@
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h1 class="h3 mb-0">Productos</h1>
         <div>
-            <a href="{% url 'productos:import' %}" class="btn btn-success me-2">
+            <a href="{% url 'productos_web:import' %}" class="btn btn-success me-2">
                 <i class="bi bi-file-earmark-spreadsheet"></i> Importar
             </a>
-            <a href="{% url 'productos:export' %}" class="btn btn-info me-2">
+            <a href="{% url 'productos_web:export' %}" class="btn btn-info me-2">
                 <i class="bi bi-download"></i> Exportar
             </a>
-            <a href="{% url 'productos:producto_create' %}" class="btn btn-primary">
+            <a href="{% url 'productos_web:producto-create' %}" class="btn btn-primary">
                 <i class="bi bi-plus-lg"></i> Nuevo Producto
             </a>
         </div>

--- a/productos/urls.py
+++ b/productos/urls.py
@@ -1,23 +1,26 @@
-# productos/urls.py
-
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import ProductoTerminadoViewSet # Importa el ViewSet que creamos
 
-# Crear un router de DRF
-# DefaultRouter crea automáticamente las URLs para las acciones estándar del ViewSet (list, create, retrieve, update, destroy)
+from .views import (
+    ProductoTerminadoViewSet,
+    ProductoListView, ProductoDetailView,
+    ProductoCreateView, ProductoUpdateView,
+    ProductoDuplicateView,
+)
+
 router = DefaultRouter()
-
-# Registrar el ViewSet con el router
-# 'productos' será el prefijo de la URL (ej: /api/v1/productos/)
-# 'ProductoTerminadoViewSet' es la clase que maneja las peticiones
-# 'basename' se usa para generar los nombres de las URLs internas de Django
 router.register(r'productos', ProductoTerminadoViewSet, basename='producto')
 
-# Nombre de la aplicación para namespacing (debe coincidir con el namespace en erp_config/urls.py)
+api_urlpatterns = [
+    path('', include(router.urls)),
+]
+
 app_name = 'productos_web'
 
-# Las urlpatterns de esta app incluyen todas las URLs generadas por el router
 urlpatterns = [
-    path('', include(router.urls)),
+    path('', ProductoListView.as_view(), name='producto-list'),
+    path('nuevo/', ProductoCreateView.as_view(), name='producto-create'),
+    path('<int:pk>/', ProductoDetailView.as_view(), name='producto-detail'),
+    path('<int:pk>/editar/', ProductoUpdateView.as_view(), name='producto-update'),
+    path('<int:pk>/duplicar/', ProductoDuplicateView.as_view(), name='producto-duplicate'),
 ]

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,11 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Font Awesome -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
+    <!-- DataTables CSS -->
+    <link href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css" rel="stylesheet">
+    <!-- Select2 CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/select2-bootstrap-5-theme@1.3.0/dist/select2-bootstrap-5-theme.min.css" rel="stylesheet">
     <!-- Custom CSS -->
     <style>
         /* Sidebar */
@@ -242,29 +247,6 @@
                     </div>
                 </li>
 
-                <!-- Inventario -->
-                <li class="nav-item">
-                    <a class="nav-link {% if request.resolver_match.app_name == 'inventario_web' %}active{% endif %}"
-                       href="#submenuInventario" data-bs-toggle="collapse">
-                        <i class="fas fa-warehouse"></i> Inventario
-                    </a>
-                    <div class="collapse {% if request.resolver_match.app_name == 'inventario_web' %}show{% endif %}" 
-                         id="submenuInventario">
-                        <ul class="nav flex-column ms-3">
-                            <li class="nav-item">
-                                <a class="nav-link" href="{% url 'inventario_web:lote-list' %}">
-                                    Lotes
-                                </a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="{% url 'inventario_web:movimiento-list' %}">
-                                    Movimientos
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
-                </li>
-
                 <!-- Productos -->
                 <li class="nav-item">
                     <a class="nav-link {% if request.resolver_match.app_name == 'productos_web' %}active{% endif %}"
@@ -376,6 +358,11 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
     <!-- jQuery -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <!-- DataTables JS -->
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+    <!-- Select2 JS -->
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     <!-- Custom JS -->
     <script>
         // Activar tooltips

--- a/templates/inventario/lote_list.html
+++ b/templates/inventario/lote_list.html
@@ -15,12 +15,12 @@
             <h6 class="m-0 font-weight-bold text-primary">Filtros</h6>
         </div>
         <div class="card-body">
-            <form method="get" class="form-inline">
-                <div class="form-group mr-2 mb-2">
+            <form method="get" class="row row-cols-lg-auto g-2 align-items-center">
+                <div class="form-group me-2 mb-2">
                     <input type="text" class="form-control" name="q" value="{{ search_query|default:'' }}" 
                            placeholder="Buscar por ID, código o nombre...">
                 </div>
-                <div class="form-group mr-2 mb-2">
+                <div class="form-group me-2 mb-2">
                     <select class="form-control" name="estado">
                         <option value="">Todos los estados</option>
                         {% for estado in estados_lote %}
@@ -33,7 +33,7 @@
                 <button type="submit" class="btn btn-primary mb-2">
                     <i class="fas fa-search"></i> Buscar
                 </button>
-                <a href="{% url 'inventario_web:lote-list' %}" class="btn btn-secondary mb-2 ml-2">
+                <a href="{% url 'inventario_web:lote-list' %}" class="btn btn-secondary mb-2 ms-2">
                     <i class="fas fa-sync-alt"></i> Limpiar
                 </a>
             </form>
@@ -43,7 +43,7 @@
     <!-- Pestañas -->
     <ul class="nav nav-tabs mb-4" id="loteTabs" role="tablist">
         <li class="nav-item">
-            <a class="nav-link active" id="mp-tab" data-toggle="tab" href="#mp" role="tab" aria-controls="mp" aria-selected="true">
+            <a class="nav-link active" id="mp-tab" data-bs-toggle="tab" href="#mp" role="tab" aria-controls="mp" aria-selected="true">
                 Materia Prima
             </a>
         </li>
@@ -143,7 +143,7 @@
 <script>
     $(document).ready(function() {
         // Inicializar tooltips
-        $('[data-toggle="tooltip"]').tooltip();
+        $('[data-bs-toggle="tooltip"]').tooltip();
         
         // Inicializar DataTables
         if ($.fn.DataTable.isDataTable('#dataTableMp')) {

--- a/templates/inventario/movimiento_list.html
+++ b/templates/inventario/movimiento_list.html
@@ -15,8 +15,8 @@
             <h6 class="m-0 font-weight-bold text-primary">Filtros</h6>
         </div>
         <div class="card-body">
-            <form method="get" class="form-inline">
-                <div class="form-group mr-2 mb-2">
+            <form method="get" class="row row-cols-lg-auto g-2 align-items-center">
+                <div class="form-group me-2 mb-2">
                     <select class="form-control" name="tipo_movimiento">
                         <option value="">Todos los tipos</option>
                         {% for tipo in tipos_movimiento %}
@@ -26,18 +26,18 @@
                         {% endfor %}
                     </select>
                 </div>
-                <div class="form-group mr-2 mb-2">
+                <div class="form-group me-2 mb-2">
                     <input type="date" class="form-control" name="fecha_desde" value="{{ fecha_desde|default:'' }}" 
                            placeholder="Desde">
                 </div>
-                <div class="form-group mr-2 mb-2">
+                <div class="form-group me-2 mb-2">
                     <input type="date" class="form-control" name="fecha_hasta" value="{{ fecha_hasta|default:'' }}" 
                            placeholder="Hasta">
                 </div>
                 <button type="submit" class="btn btn-primary mb-2">
                     <i class="fas fa-search"></i> Buscar
                 </button>
-                <a href="{% url 'inventario_web:movimiento-list' %}" class="btn btn-secondary mb-2 ml-2">
+                <a href="{% url 'inventario_web:movimiento-list' %}" class="btn btn-secondary mb-2 ms-2">
                     <i class="fas fa-sync-alt"></i> Limpiar
                 </a>
             </form>
@@ -139,7 +139,7 @@
 <script>
     $(document).ready(function() {
         // Inicializar tooltips
-        $('[data-toggle="tooltip"]').tooltip();
+        $('[data-bs-toggle="tooltip"]').tooltip();
         
         // Inicializar DataTables
         if ($.fn.DataTable.isDataTable('#dataTableMovimientos')) {


### PR DESCRIPTION
## Summary
- add `ProductoTerminadoForm`
- implement product list/detail/create/update/duplicate views
- register product web URLs and expose API routes separately
- create detail and stock views for inventory
- fix missing `Q` import and template paths for clientes and personal apps
- update templates to use correct namespaces

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*